### PR TITLE
Add face tagging API endpoints

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -12,7 +12,7 @@ from PIL import Image
 from sqlalchemy.orm import Session
 
 from lucos_photos_common.database import SessionLocal
-from lucos_photos_common.models import Photo, ProcessingState, ProcessingStatus
+from lucos_photos_common.models import Face, Person, Photo, PhotoPerson, ProcessingState, ProcessingStatus
 
 app = FastAPI(title="lucos_photos")
 
@@ -179,3 +179,122 @@ async def upload_photo(
     await emit_loganne_event("photoAdded", f"Photo {photo.id} added to lucos_photos")
 
     return photo_to_dict(photo)
+
+
+def face_to_dict(face: Face) -> dict:
+    return {
+        "id": str(face.id),
+        "photoId": str(face.photo_id),
+        "personId": str(face.person_id) if face.person_id else None,
+        "personConfirmed": face.person_confirmed,
+        "boundingBox": {
+            "x": face.bbox_x,
+            "y": face.bbox_y,
+            "width": face.bbox_width,
+            "height": face.bbox_height,
+        },
+    }
+
+
+def sync_photo_person(db: Session, photo_id, person_id=None) -> None:
+    """Ensure photo_person table reflects all confirmed/unconfirmed person assignments for a photo."""
+    # Collect the set of person_ids currently assigned to faces for this photo
+    face_person_ids = {
+        f.person_id
+        for f in db.query(Face).filter(Face.photo_id == photo_id, Face.person_id.is_not(None)).all()
+    }
+
+    # Remove photo_person rows for persons no longer assigned to any face
+    existing_rows = db.query(PhotoPerson).filter(PhotoPerson.photo_id == photo_id).all()
+    for row in existing_rows:
+        if row.person_id not in face_person_ids:
+            db.delete(row)
+
+    # Add missing photo_person rows
+    existing_person_ids = {row.person_id for row in existing_rows}
+    for pid in face_person_ids:
+        if pid not in existing_person_ids:
+            db.add(PhotoPerson(photo_id=photo_id, person_id=pid))
+
+
+@app.get("/photos/{photo_id}/faces")
+def list_faces(
+    photo_id: str,
+    _: Annotated[None, Depends(verify_key)],
+    db: Session = Depends(get_db),
+):
+    try:
+        import uuid as _uuid
+        photo_uuid = _uuid.UUID(photo_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Photo not found")
+
+    photo = db.query(Photo).filter(Photo.id == photo_uuid).first()
+    if not photo:
+        raise HTTPException(status_code=404, detail="Photo not found")
+
+    faces = db.query(Face).filter(Face.photo_id == photo_uuid).all()
+    return [face_to_dict(f) for f in faces]
+
+
+@app.put("/faces/{face_id}/person")
+async def assign_person(
+    face_id: str,
+    body: dict,
+    _: Annotated[None, Depends(verify_key)],
+    db: Session = Depends(get_db),
+):
+    try:
+        import uuid as _uuid
+        face_uuid = _uuid.UUID(face_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Face not found")
+
+    face = db.query(Face).filter(Face.id == face_uuid).first()
+    if not face:
+        raise HTTPException(status_code=404, detail="Face not found")
+
+    person_id_str = body.get("personId")
+    if not person_id_str:
+        raise HTTPException(status_code=422, detail="personId is required")
+
+    try:
+        person_uuid = _uuid.UUID(person_id_str)
+    except ValueError:
+        raise HTTPException(status_code=422, detail="personId must be a valid UUID")
+
+    person = db.query(Person).filter(Person.id == person_uuid).first()
+    if not person:
+        raise HTTPException(status_code=404, detail="Person not found")
+
+    face.person_id = person_uuid
+    face.person_confirmed = True
+    sync_photo_person(db, face.photo_id)
+    db.commit()
+    db.refresh(face)
+
+    await emit_loganne_event("personTagged", f"Person {person_uuid} tagged on face {face_uuid} in photo {face.photo_id}")
+
+    return face_to_dict(face)
+
+
+@app.delete("/faces/{face_id}/person", status_code=status.HTTP_204_NO_CONTENT)
+def unassign_person(
+    face_id: str,
+    _: Annotated[None, Depends(verify_key)],
+    db: Session = Depends(get_db),
+):
+    try:
+        import uuid as _uuid
+        face_uuid = _uuid.UUID(face_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Face not found")
+
+    face = db.query(Face).filter(Face.id == face_uuid).first()
+    if not face:
+        raise HTTPException(status_code=404, detail="Face not found")
+
+    face.person_id = None
+    face.person_confirmed = False
+    sync_photo_person(db, face.photo_id)
+    db.commit()

--- a/api/tests/test_faces.py
+++ b/api/tests/test_faces.py
@@ -1,0 +1,329 @@
+import uuid
+
+import pytest
+
+from lucos_photos_common.models import Face, Person, Photo, PhotoPerson
+
+AUTH_HEADER = {"Authorization": "key validkey"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_photo(db):
+    photo = Photo(sha256_hash="a" * 64, file_extension="jpg")
+    db.add(photo)
+    db.flush()
+    return photo
+
+
+def make_person(db, display_name="Alice"):
+    person = Person(display_name=display_name)
+    db.add(person)
+    db.flush()
+    return person
+
+
+def make_face(db, photo, person=None, confirmed=False):
+    face = Face(
+        photo_id=photo.id,
+        person_id=person.id if person else None,
+        person_confirmed=confirmed,
+        bbox_x=0.1,
+        bbox_y=0.2,
+        bbox_width=0.3,
+        bbox_height=0.4,
+    )
+    db.add(face)
+    db.flush()
+    return face
+
+
+# ---------------------------------------------------------------------------
+# GET /photos/{photo_id}/faces
+# ---------------------------------------------------------------------------
+
+class TestListFaces:
+    def test_returns_empty_list_when_no_faces(self, client, db_session):
+        photo = make_photo(db_session)
+        db_session.commit()
+
+        response = client.get(f"/photos/{photo.id}/faces", headers=AUTH_HEADER)
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_returns_faces_for_photo(self, client, db_session):
+        photo = make_photo(db_session)
+        face = make_face(db_session, photo)
+        db_session.commit()
+
+        response = client.get(f"/photos/{photo.id}/faces", headers=AUTH_HEADER)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["id"] == str(face.id)
+        assert data[0]["photoId"] == str(photo.id)
+        assert data[0]["personId"] is None
+        assert data[0]["personConfirmed"] is False
+        assert data[0]["boundingBox"] == {"x": 0.1, "y": 0.2, "width": 0.3, "height": 0.4}
+
+    def test_returns_face_with_person_assigned(self, client, db_session):
+        photo = make_photo(db_session)
+        person = make_person(db_session)
+        face = make_face(db_session, photo, person=person, confirmed=True)
+        db_session.commit()
+
+        response = client.get(f"/photos/{photo.id}/faces", headers=AUTH_HEADER)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["personId"] == str(person.id)
+        assert data[0]["personConfirmed"] is True
+
+    def test_only_returns_faces_for_requested_photo(self, client, db_session):
+        photo1 = make_photo(db_session)
+        photo2 = Photo(sha256_hash="b" * 64, file_extension="jpg")
+        db_session.add(photo2)
+        db_session.flush()
+        make_face(db_session, photo1)
+        make_face(db_session, photo2)
+        db_session.commit()
+
+        response = client.get(f"/photos/{photo1.id}/faces", headers=AUTH_HEADER)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["photoId"] == str(photo1.id)
+
+    def test_returns_404_for_unknown_photo(self, client, db_session):
+        response = client.get(f"/photos/{uuid.uuid4()}/faces", headers=AUTH_HEADER)
+        assert response.status_code == 404
+
+    def test_returns_404_for_invalid_uuid(self, client, db_session):
+        response = client.get("/photos/not-a-uuid/faces", headers=AUTH_HEADER)
+        assert response.status_code == 404
+
+    def test_requires_authentication(self, client, db_session):
+        photo = make_photo(db_session)
+        db_session.commit()
+        response = client.get(f"/photos/{photo.id}/faces")
+        assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# PUT /faces/{face_id}/person
+# ---------------------------------------------------------------------------
+
+class TestAssignPerson:
+    def test_assigns_person_to_face(self, client, db_session):
+        photo = make_photo(db_session)
+        person = make_person(db_session)
+        face = make_face(db_session, photo)
+        db_session.commit()
+
+        response = client.put(
+            f"/faces/{face.id}/person",
+            json={"personId": str(person.id)},
+            headers=AUTH_HEADER,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["personId"] == str(person.id)
+        assert data["personConfirmed"] is True
+
+    def test_marks_person_confirmed_true(self, client, db_session):
+        photo = make_photo(db_session)
+        person = make_person(db_session)
+        face = make_face(db_session, photo)
+        db_session.commit()
+
+        client.put(
+            f"/faces/{face.id}/person",
+            json={"personId": str(person.id)},
+            headers=AUTH_HEADER,
+        )
+        db_session.refresh(face)
+        assert face.person_confirmed is True
+
+    def test_updates_photo_person_table(self, client, db_session):
+        photo = make_photo(db_session)
+        person = make_person(db_session)
+        face = make_face(db_session, photo)
+        db_session.commit()
+
+        client.put(
+            f"/faces/{face.id}/person",
+            json={"personId": str(person.id)},
+            headers=AUTH_HEADER,
+        )
+
+        pp = db_session.query(PhotoPerson).filter(
+            PhotoPerson.photo_id == photo.id,
+            PhotoPerson.person_id == person.id,
+        ).first()
+        assert pp is not None
+
+    def test_reassigns_face_to_different_person(self, client, db_session):
+        photo = make_photo(db_session)
+        person1 = make_person(db_session, "Alice")
+        person2 = make_person(db_session, "Bob")
+        face = make_face(db_session, photo, person=person1, confirmed=True)
+        db_session.add(PhotoPerson(photo_id=photo.id, person_id=person1.id))
+        db_session.commit()
+
+        client.put(
+            f"/faces/{face.id}/person",
+            json={"personId": str(person2.id)},
+            headers=AUTH_HEADER,
+        )
+
+        # Old photo_person row should be removed, new one added
+        old_pp = db_session.query(PhotoPerson).filter(
+            PhotoPerson.photo_id == photo.id,
+            PhotoPerson.person_id == person1.id,
+        ).first()
+        new_pp = db_session.query(PhotoPerson).filter(
+            PhotoPerson.photo_id == photo.id,
+            PhotoPerson.person_id == person2.id,
+        ).first()
+        assert old_pp is None
+        assert new_pp is not None
+
+    def test_returns_404_for_unknown_face(self, client, db_session):
+        person = make_person(db_session)
+        db_session.commit()
+        response = client.put(
+            f"/faces/{uuid.uuid4()}/person",
+            json={"personId": str(person.id)},
+            headers=AUTH_HEADER,
+        )
+        assert response.status_code == 404
+
+    def test_returns_404_for_unknown_person(self, client, db_session):
+        photo = make_photo(db_session)
+        face = make_face(db_session, photo)
+        db_session.commit()
+        response = client.put(
+            f"/faces/{face.id}/person",
+            json={"personId": str(uuid.uuid4())},
+            headers=AUTH_HEADER,
+        )
+        assert response.status_code == 404
+
+    def test_returns_422_when_person_id_missing(self, client, db_session):
+        photo = make_photo(db_session)
+        face = make_face(db_session, photo)
+        db_session.commit()
+        response = client.put(
+            f"/faces/{face.id}/person",
+            json={},
+            headers=AUTH_HEADER,
+        )
+        assert response.status_code == 422
+
+    def test_returns_422_for_invalid_person_uuid(self, client, db_session):
+        photo = make_photo(db_session)
+        face = make_face(db_session, photo)
+        db_session.commit()
+        response = client.put(
+            f"/faces/{face.id}/person",
+            json={"personId": "not-a-uuid"},
+            headers=AUTH_HEADER,
+        )
+        assert response.status_code == 422
+
+    def test_requires_authentication(self, client, db_session):
+        photo = make_photo(db_session)
+        person = make_person(db_session)
+        face = make_face(db_session, photo)
+        db_session.commit()
+        response = client.put(
+            f"/faces/{face.id}/person",
+            json={"personId": str(person.id)},
+        )
+        assert response.status_code == 401
+
+    def test_emits_loganne_event(self, client, db_session):
+        from unittest.mock import AsyncMock, patch
+        photo = make_photo(db_session)
+        person = make_person(db_session)
+        face = make_face(db_session, photo)
+        db_session.commit()
+
+        with patch("app.main.emit_loganne_event", new_callable=AsyncMock) as mock_emit:
+            client.put(
+                f"/faces/{face.id}/person",
+                json={"personId": str(person.id)},
+                headers=AUTH_HEADER,
+            )
+            mock_emit.assert_called_once()
+            call_args = mock_emit.call_args
+            assert call_args[0][0] == "personTagged"
+
+
+# ---------------------------------------------------------------------------
+# DELETE /faces/{face_id}/person
+# ---------------------------------------------------------------------------
+
+class TestUnassignPerson:
+    def test_clears_person_from_face(self, client, db_session):
+        photo = make_photo(db_session)
+        person = make_person(db_session)
+        face = make_face(db_session, photo, person=person, confirmed=True)
+        db_session.add(PhotoPerson(photo_id=photo.id, person_id=person.id))
+        db_session.commit()
+
+        response = client.delete(f"/faces/{face.id}/person", headers=AUTH_HEADER)
+        assert response.status_code == 204
+
+        db_session.refresh(face)
+        assert face.person_id is None
+        assert face.person_confirmed is False
+
+    def test_removes_photo_person_row_when_no_faces_have_person(self, client, db_session):
+        photo = make_photo(db_session)
+        person = make_person(db_session)
+        face = make_face(db_session, photo, person=person, confirmed=True)
+        db_session.add(PhotoPerson(photo_id=photo.id, person_id=person.id))
+        db_session.commit()
+
+        client.delete(f"/faces/{face.id}/person", headers=AUTH_HEADER)
+
+        pp = db_session.query(PhotoPerson).filter(
+            PhotoPerson.photo_id == photo.id,
+            PhotoPerson.person_id == person.id,
+        ).first()
+        assert pp is None
+
+    def test_keeps_photo_person_row_when_another_face_still_has_person(self, client, db_session):
+        photo = make_photo(db_session)
+        person = make_person(db_session)
+        face1 = make_face(db_session, photo, person=person, confirmed=True)
+        make_face(db_session, photo, person=person, confirmed=False)
+        db_session.add(PhotoPerson(photo_id=photo.id, person_id=person.id))
+        db_session.commit()
+
+        client.delete(f"/faces/{face1.id}/person", headers=AUTH_HEADER)
+
+        pp = db_session.query(PhotoPerson).filter(
+            PhotoPerson.photo_id == photo.id,
+            PhotoPerson.person_id == person.id,
+        ).first()
+        assert pp is not None
+
+    def test_returns_404_for_unknown_face(self, client, db_session):
+        response = client.delete(f"/faces/{uuid.uuid4()}/person", headers=AUTH_HEADER)
+        assert response.status_code == 404
+
+    def test_returns_404_for_invalid_uuid(self, client, db_session):
+        response = client.delete("/faces/not-a-uuid/person", headers=AUTH_HEADER)
+        assert response.status_code == 404
+
+    def test_requires_authentication(self, client, db_session):
+        photo = make_photo(db_session)
+        person = make_person(db_session)
+        face = make_face(db_session, photo, person=person, confirmed=True)
+        db_session.commit()
+        response = client.delete(f"/faces/{face.id}/person")
+        assert response.status_code == 401


### PR DESCRIPTION
Closes #15

## Changes

### New API endpoints

**GET /photos/{id}/faces**
- Lists all detected faces for a given photo
- Returns bounding box coordinates (normalised 0.0–1.0) and current person assignment
- 404 if photo not found

**PUT /faces/{id}/person**
- Assigns a face to a specific person
- Sets `person_id` and `person_confirmed=True`
- Syncs the `photo_person` table (adds row if not already present; removes stale rows for persons no longer assigned to any face in the photo)
- Emits a `personTagged` Loganne event
- 404 if face or person not found, 422 if `personId` is missing or not a valid UUID

**DELETE /faces/{id}/person**
- Unassigns a face from a person
- Clears `person_id` and sets `person_confirmed=False`
- Syncs the `photo_person` table accordingly (removes row only if no other face in the same photo still references that person)
- 204 No Content on success

All three endpoints require key authentication.

## Tests

23 new test cases in `tests/test_faces.py` covering happy paths, auth, 404s, 422s, photo_person sync, and Loganne event emission.